### PR TITLE
[feature] add helper methods to interact with types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,20 @@ jobs:
           command: yarn run test
           name: Run Tests
 
+  build:
+    <<: *env_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          command: yarn run build
+          name: Build
+
 orbs:
   node: circleci/node@4.1.0
 workflows:
-  test:
+  testAndBuild:
     jobs:
       - prepare:
           pre-steps:
@@ -54,4 +64,8 @@ workflows:
       - test:
           requires:
             - prepare
+      - build:
+          requires:
+            - test
+
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zoralabs/zdk",
   "description": "An SDK for using the Zora Media Protocol",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-import Decimal from '@zoralabs/core/dist/utils/Decimal'
-
-export { Decimal }
-
 export * from './zora'
 export * from './types'
 export * from './utils'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,12 @@
-import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
+import { BigNumberish } from '@ethersproject/bignumber'
 import { BytesLike } from '@ethersproject/bytes'
+import Decimal from '@zoralabs/core/dist/utils/Decimal'
+export { Decimal }
 
-export type DecimalValue = { value: BigNumber }
+/**
+ * Internal type to represent a Decimal Value
+ */
+type DecimalValue = { value: BigNumberish }
 
 /**
  * Zora Media Protocol BidShares

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,9 +2,134 @@ import { getAddress } from '@ethersproject/address'
 import warning from 'tiny-warning'
 import invariant from 'tiny-invariant'
 import sjcl from 'sjcl'
+import { Ask, Bid, BidShares, Decimal, MediaData } from './types'
+import { BigNumberish, BytesLike } from 'ethers'
+
+/**
+ * Constructs a MediaData type.
+ *
+ * @param tokenURI
+ * @param metadataURI
+ * @param contentHash
+ * @param metadataHash
+ */
+export function constructMediaData(
+  tokenURI: string,
+  metadataURI: string,
+  contentHash: BytesLike,
+  metadataHash: BytesLike
+): MediaData {
+  // validate the hash to ensure it fits in bytes32
+  validateBytes32(contentHash)
+  validateBytes32(metadataHash)
+
+  return {
+    tokenURI: tokenURI,
+    metadataURI: metadataURI,
+    contentHash: contentHash,
+    metadataHash: metadataHash,
+  }
+}
+
+/**
+ * Constructs a BidShares type.
+ * Throws an error if the BidShares do not sum to 100 with 18 trailing decimals.
+ *
+ * @param creator
+ * @param owner
+ * @param prevOwner
+ */
+export function constructBidShares(
+  creator: number,
+  owner: number,
+  prevOwner: number
+): BidShares {
+  const decimalCreator = Decimal.new(parseFloat(creator.toFixed(4)))
+  const decimalOwner = Decimal.new(parseFloat(owner.toFixed(4)))
+  const decimalPrevOwner = Decimal.new(parseFloat(prevOwner.toFixed(4)))
+  const decimal100 = Decimal.new(100)
+
+  const sum = decimalCreator.value.add(decimalOwner.value).add(decimalPrevOwner.value)
+
+  if (sum.toString() != decimal100.value.toString()) {
+    throw new Error(
+      `The BidShares sum to ${sum.toString()}, but they must sum to ${decimal100.value.toString()}`
+    )
+  }
+
+  return {
+    creator: decimalCreator,
+    owner: decimalOwner,
+    prevOwner: decimalPrevOwner,
+  }
+}
+
+/**
+ * Constructs an Ask.
+ *
+ * @param currency
+ * @param amount
+ */
+export function constructAsk(currency: string, amount: BigNumberish): Ask {
+  const parsedCurrency = validateAndParseAddress(currency)
+  return {
+    currency: parsedCurrency,
+    amount: amount,
+  }
+}
+
+/**
+ * Constructs a Bid.
+ *
+ * @param currency
+ * @param amount
+ * @param bidder
+ * @param recipient
+ * @param sellOnShare
+ */
+export function constructBid(
+  currency: string,
+  amount: BigNumberish,
+  bidder: string,
+  recipient: string,
+  sellOnShare: number
+): Bid {
+  let parsedCurrency: string
+  let parsedBidder: string
+  let parsedRecipient: string
+
+  try {
+    parsedCurrency = validateAndParseAddress(currency)
+  } catch (err) {
+    throw new Error(`Currency address is invalid: ${err.message}`)
+  }
+
+  try {
+    parsedBidder = validateAndParseAddress(bidder)
+  } catch (err) {
+    throw new Error(`Bidder address is invalid: ${err.message}`)
+  }
+
+  try {
+    parsedRecipient = validateAndParseAddress(recipient)
+  } catch (err) {
+    throw new Error(`Recipient address is invalid: ${err.message}`)
+  }
+
+  const decimalSellOnShare = Decimal.new(parseFloat(sellOnShare.toFixed(4)))
+
+  return {
+    currency: parsedCurrency,
+    amount: amount,
+    bidder: parsedBidder,
+    recipient: parsedRecipient,
+    sellOnShare: decimalSellOnShare,
+  }
+}
 
 /**
  * Validates and returns the checksummed address
+ *
  * @param address
  */
 export function validateAndParseAddress(address: string): string {
@@ -19,12 +144,16 @@ export function validateAndParseAddress(address: string): string {
 
 /**
  * Returns the proper network name for the specified chainId
+ *
  * @param chainId
  */
 export function chainIdToNetworkName(chainId: number): string {
   switch (chainId) {
     case 4: {
       return 'rinkeby'
+    }
+    case 1: {
+      return 'mainnet'
     }
   }
 
@@ -33,6 +162,7 @@ export function chainIdToNetworkName(chainId: number): string {
 
 /**
  * Generates the sha256 hash from a buffer and returns the hash hex-encoded
+ *
  * @param buffer
  */
 export function sha256FromBuffer(buffer: Buffer): string {
@@ -43,14 +173,12 @@ export function sha256FromBuffer(buffer: Buffer): string {
 
 /**
  * Generates a sha256 hash from a hex string and returns the hash hex-encoded.
- * Throws an error if `data` is not a hex string
+ * Throws an error if `data` is not a hex string.
+ *
  * @param data
  */
 export function sha256FromHexString(data: string): string {
-  const hexRegex = new RegExp(/^(0x)?[0-9a-f]+$/i)
-  const validHex = hexRegex.test(data)
-
-  if (!validHex) {
+  if (!isHexString(data)) {
     throw new Error(`${data} is not valid hex`)
   }
 
@@ -92,4 +220,18 @@ export function sha256FromFile(pathToFile: string, chunkSize: number): Promise<s
       reject(err)
     })
   })
+}
+
+function validateBytes32(value: BytesLike) {
+  if (isHexString(value) && value.length == 64) {
+    return
+  } else if (value.length == 32) {
+    return
+  }
+
+  invariant(false, `${value.toString()} is not exactly 32 bytes`)
+}
+
+function isHexString(value: any): boolean {
+  return !(typeof value !== 'string' || !new RegExp(/^(0x)?[0-9a-f]+$/i).test(value))
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,8 +1,18 @@
 import chai, { expect } from 'chai'
 import asPromised from 'chai-as-promised'
 import spies from 'chai-spies'
-import { sha256FromBuffer, sha256FromFile, sha256FromHexString } from '../src/utils'
+import {
+  constructAsk,
+  constructBid,
+  constructBidShares,
+  constructMediaData,
+  sha256FromBuffer,
+  sha256FromFile,
+  sha256FromHexString,
+} from '../src/utils'
 import { promises as fs } from 'fs'
+import { Decimal } from '../src'
+import { ethers } from 'ethers'
 
 chai.use(asPromised)
 chai.use(spies)
@@ -16,7 +26,7 @@ describe('Utils', async () => {
     kanyeHash = 'e5dc4ed07fa1a3464d618a5d52a983880bb908b99ffff479eb7ebb7f7b11dabb'
   })
 
-  describe('sha256FromFile', async () => {
+  describe('#sha256FromFile', async () => {
     it('it properly hashes a file smaller than the chunk size', async () => {
       expect(sha256FromFile('../fixtures/HelloWorld.txt', 16 * 1024)).eventually.eq(hash)
     })
@@ -26,14 +36,14 @@ describe('Utils', async () => {
     })
   })
 
-  describe('sha256FromBuffer', async () => {
+  describe('#sha256FromBuffer', async () => {
     it('it properly hashes from buffer', async () => {
       const kanyeBuf = await fs.readFile('./fixtures/kanye.jpg')
       expect(sha256FromBuffer(kanyeBuf)).eq(kanyeHash)
     })
   })
 
-  describe('sha256FromHexString', async () => {
+  describe('#sha256FromHexString', async () => {
     it('it properly hashes from hex string', async () => {
       const kanyeBuf = await fs.readFile('./fixtures/kanye.jpg')
       const hexString = kanyeBuf.toString('hex')
@@ -45,6 +55,190 @@ describe('Utils', async () => {
       expect(() => {
         sha256FromHexString(invalidHex)
       }).to.throw(`${invalidHex} is not valid hex`)
+    })
+  })
+
+  describe('#constructMediaData', () => {
+    it('creates MediaData', () => {
+      const metadataHex = ethers.utils.formatBytes32String('some metadata')
+      const contentHex = ethers.utils.formatBytes32String('some content')
+      const contentHash = sha256FromHexString(contentHex)
+      const metadataHash = sha256FromHexString(metadataHex)
+      const media = constructMediaData(
+        'some content uri',
+        'some metadata uri',
+        contentHash,
+        metadataHash
+      )
+      expect(media.tokenURI).eq('some content uri')
+      expect(media.metadataURI).eq('some metadata uri')
+      expect(media.contentHash).eq(contentHash)
+      expect(media.metadataHash).eq(metadataHash)
+    })
+
+    it('throws an error if the content hash is hexstring greater than 32 bytes', () => {
+      const metadataHex = ethers.utils.formatBytes32String('some metadata')
+      const contentHex = ethers.utils.formatBytes32String('some content')
+      const contentHash = sha256FromHexString(contentHex)
+      const metadataHash = sha256FromHexString(metadataHex)
+      expect(() => {
+        constructMediaData(
+          'some content uri',
+          'some metadata uri',
+          contentHash.concat('zmxnx'),
+          metadataHash.concat('42n3jk')
+        )
+      }).to.throw(
+        `Invariant failed: ${contentHash.concat('zmxnx')} is not exactly 32 bytes`
+      )
+    })
+
+    it('throws an error if the content hash is hexstring less than 32 bytes', () => {
+      const metadataHex = ethers.utils.formatBytes32String('some metadata')
+      const contentHex = ethers.utils.formatBytes32String('some content')
+      const contentHash = sha256FromHexString(contentHex)
+      const metadataHash = sha256FromHexString(metadataHex)
+      expect(() => {
+        constructMediaData(
+          'some content uri',
+          'some metadata uri',
+          contentHash.substr(0, 62),
+          metadataHash
+        )
+      }).to.throw(
+        `Invariant failed: ${contentHash.substr(0, 62)} is not exactly 32 bytes`
+      )
+    })
+
+    it('throws an error if the content hash is byte array less than 32 bytes', () => {
+      const contentHex = ethers.utils.formatBytes32String('some content')
+      const contentHash = sha256FromHexString(contentHex)
+      const badContentHash = Uint8Array.from(Buffer.from(contentHash.substr(0, 62)))
+      const metadataHex = ethers.utils.formatBytes32String('some metadata')
+      const metadataHash = sha256FromHexString(metadataHex)
+      expect(() => {
+        constructMediaData(
+          'some content uri',
+          'some metadata uri',
+          badContentHash,
+          metadataHash
+        )
+      }).to.throw(`Invariant failed: ${badContentHash} is not exactly 32 bytes`)
+    })
+
+    it('throws an error if the content hash is byte array greater than 32 bytes', () => {
+      const metadataHex = ethers.utils.formatBytes32String('some metadata')
+      const contentHex = ethers.utils.formatBytes32String('some content')
+      const contentHash = sha256FromHexString(contentHex)
+      const badContentHash = Uint8Array.from(Buffer.from(contentHash.concat('87cz')))
+      const metadataHash = sha256FromHexString(metadataHex)
+      expect(() => {
+        constructMediaData(
+          'some content uri',
+          'some metadata uri',
+          badContentHash,
+          metadataHash
+        )
+      }).to.throw(`Invariant failed: ${badContentHash} is not exactly 32 bytes`)
+    })
+  })
+
+  describe('#constructBidShares', () => {
+    it('it raises if the BidShares do not exactly sum to 100 with 18 decimals', () => {
+      expect(() => {
+        constructBidShares(25, 24.44445, 50.55555)
+      }).to.throw(
+        `The BidShares sum to 99999900000000000000, but they must sum to 100000000000000000000`
+      )
+    })
+
+    it('it fixes 4 decimal points of precision', () => {
+      const bidShares = constructBidShares(25, 24.44455, 50.5555)
+      expect(bidShares.owner.value.toString()).to.eq(
+        Decimal.new(24.4445).value.toString()
+      )
+    })
+
+    it('it rounds up to the 4th decimal point of precision', () => {
+      const bidShares = constructBidShares(25, 24.44449, 50.5555)
+      expect(bidShares.owner.value.toString()).to.eq(
+        Decimal.new(24.4445).value.toString()
+      )
+    })
+  })
+
+  describe('#constructAsk', () => {
+    const dai = '0x6b175474e89094c44da98b954eedeac495271d0f'
+    const decimal100 = Decimal.new(100)
+
+    it('creates an ask', () => {
+      const ask = constructAsk(dai, decimal100.value)
+      expect(ask.currency.toLowerCase()).eq(dai.toLowerCase())
+      expect(ask.amount.toString()).eq(decimal100.value.toString())
+    })
+
+    it('raises if an invalid currency address is specified', () => {
+      expect(() => {
+        constructAsk(dai.substr(0, 38), decimal100.value)
+      }).to.throw(`${dai.substr(0, 38)} is not a valid address.`)
+    })
+  })
+
+  describe('#constructBid', () => {
+    const dai = '0x6b175474e89094c44da98b954eedeac495271d0f'
+    const decimal100 = Decimal.new(100)
+    const bidder = '0xf13090cC20613BF9b5F0b3E6E83CCAdB5Cd0FbD5'
+
+    it('creates a Bid', () => {
+      const bid = constructBid(dai, decimal100.value, bidder, bidder, 10)
+      expect(bid.currency.toLowerCase()).eq(dai)
+      expect(bid.amount.toString()).eq(decimal100.value.toString())
+      expect(bid.bidder.toLowerCase()).eq(bidder.toLowerCase())
+      expect(bid.recipient.toLowerCase()).eq(bidder.toLowerCase())
+      expect(bid.sellOnShare.value.toString()).eq(Decimal.new(10).value.toString())
+    })
+
+    it('it fixes the sell on share precision to 4 decimal places', () => {
+      const bid = constructBid(dai, decimal100.value, bidder, bidder, 10.1111111111)
+      expect(bid.sellOnShare.value.toString()).eq(Decimal.new(10.1111).value.toString())
+    })
+
+    it('rounds up to the 4th decimal place of the sell on share', () => {
+      const bid = constructBid(dai, decimal100.value, bidder, bidder, 10.11119999)
+      expect(bid.sellOnShare.value.toString()).eq(Decimal.new(10.1112).value.toString())
+    })
+
+    it('raises if an invalid currency address is specified', () => {
+      expect(() => {
+        constructBid(dai.substr(0, 38), decimal100.value, bidder, bidder, 10)
+      }).to.throw(
+        `Currency address is invalid: Invariant failed: ${dai.substr(
+          0,
+          38
+        )} is not a valid address.`
+      )
+    })
+
+    it('raises if an invalid bidder address is specified', () => {
+      expect(() => {
+        constructBid(dai, decimal100.value, bidder.substr(0, 10), bidder, 10)
+      }).to.throw(
+        `Bidder address is invalid: Invariant failed: ${bidder.substr(
+          0,
+          10
+        )} is not a valid address.`
+      )
+    })
+
+    it('raises if an invalid recipient address is specified', () => {
+      expect(() => {
+        constructBid(dai, decimal100.value, bidder, bidder.substr(0, 10), 10)
+      }).to.throw(
+        `Recipient address is invalid: Invariant failed: ${bidder.substr(
+          0,
+          10
+        )} is not a valid address.`
+      )
     })
   })
 })

--- a/tests/zora.test.ts
+++ b/tests/zora.test.ts
@@ -9,7 +9,7 @@ import { ZoraConfiguredAddresses } from './helpers'
 import { generatedWallets } from '@zoralabs/core/dist/utils'
 import spies from 'chai-spies'
 import { MarketFactory, MediaFactory } from '@zoralabs/core/dist/typechain'
-import Decimal from '@zoralabs/core/dist/utils/Decimal'
+import { Decimal } from '../src/types'
 import { utils } from 'ethers'
 
 chai.use(asPromised)


### PR DESCRIPTION
This PR adds exported helper functions in `utils` so that users of the sdk can safely generate the proper types for interacting with Zora Contracts. 

It also adds a build step to `circleci` and moves the export of `Decimal` to `types.ts`