### PR TITLE
[chore] Fix broken links in docs

### DIFF
--- a/docs/minting.md
+++ b/docs/minting.md
@@ -48,12 +48,12 @@ To construct the metadata of a piece of cryptomedia, use the `generateMetadata` 
 #### contentHash
 
 The sha256 hash of the content the cryptomedia represents. It is imperative that this hash is correct, because once it is written to the blockchain it **cannot** be changed.
-To generate this hash use any of the sha256 utils defined in [utils](../reference/utils).
+To generate this hash use any of the sha256 utils defined in [utils](https://github.com/ourzora/zdk/blob/master/docs/utils.md).
 
 #### metadataHash
 
 The sha256 hash of the metadata of the cryptomedia. It is imperative that this hash is correct, because once it is written to the blockchain it **cannot** be changed.
-To generate this hash use any of the sha256 utils defined in [utils](../reference/utils).
+To generate this hash use any of the sha256 utils defined in [utils](https://github.com/ourzora/zdk/blob/master/docs/utils.md).
 
 #### Example
 

--- a/docs/minting.md
+++ b/docs/minting.md
@@ -43,7 +43,7 @@ The uri where the cryptomedia's metadata is hosted. This could link to any stora
 
 The metadata uri must be prefixed with `https://` or at mint time the sdk will reject it.
 
-To construct the metadata of a piece of cryptomedia, use the `generateMetadata` function defined in `metadata.ts`. For more info visit [Metadata](../reference/metadata)
+To construct the metadata of a piece of cryptomedia, use the `generateMetadata` function defined in `metadata.ts`. For more info visit [Metadata](https://github.com/ourzora/zdk/blob/master/docs/metadata.md)
 
 #### contentHash
 

--- a/docs/minting.md
+++ b/docs/minting.md
@@ -43,7 +43,7 @@ The uri where the cryptomedia's metadata is hosted. This could link to any stora
 
 The metadata uri must be prefixed with `https://` or at mint time the sdk will reject it.
 
-To construct the metadata of a piece of cryptomedia, use the `generateMetadata` function defined in `metadata.ts`. For more info visit [Metadata](https://github.com/ourzora/zdk/blob/master/docs/metadata.md)
+To construct the metadata of a piece of cryptomedia, use the `generateMetadata` function defined in `metadata.ts`. For more info visit [Metadata](../docs/metadata.md)
 
 #### contentHash
 

--- a/docs/minting.md
+++ b/docs/minting.md
@@ -48,12 +48,12 @@ To construct the metadata of a piece of cryptomedia, use the `generateMetadata` 
 #### contentHash
 
 The sha256 hash of the content the cryptomedia represents. It is imperative that this hash is correct, because once it is written to the blockchain it **cannot** be changed.
-To generate this hash use any of the sha256 utils defined in [utils](https://github.com/ourzora/zdk/blob/master/docs/utils.md).
+To generate this hash use any of the sha256 utils defined in [utils](../docs/utils.md).
 
 #### metadataHash
 
 The sha256 hash of the metadata of the cryptomedia. It is imperative that this hash is correct, because once it is written to the blockchain it **cannot** be changed.
-To generate this hash use any of the sha256 utils defined in [utils](https://github.com/ourzora/zdk/blob/master/docs/utils.md).
+To generate this hash use any of the sha256 utils defined in [utils](../docs/utils.md).
 
 #### Example
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,6 +1,0 @@
-The ZDK has 4 primary exports plus some types:
-
-- [Zora](docs/zora.md)
-- [Utils](docs/utils.md)
-- [Addresses](docs/addresses.md)
-- [Metadata](docs/metadata.md)

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,6 @@
+The ZDK has 4 primary exports plus some types:
+
+- [Zora](docs/zora.md)
+- [Utils](docs/utils.md)
+- [Addresses](docs/addresses.md)
+- [Metadata](docs/metadata.md)

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -10,7 +10,7 @@ The utility functions can roughly be split into 3 categories:
 
 ### Type Constructors
 
-There are a number of [Types](src/types.ts) that are necessary to interact with a Zora instance.
+There are a number of [Types](../src/types.ts) that are necessary to interact with a Zora instance.
 The type constructors accept input, perform basic validation on the input, and return the properly formatted Zora Type.
 
 #### constructMediaData


### PR DESCRIPTION
On the minting page, the links to metadata and the utils docs are broken and give 404s. Also, there is no types.md doc page even though it's linked on the utils.md doc