### PR TITLE
nit: License

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "author": "Zora",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "private": false,
   "scripts": {
     "make-badges": "istanbul-badges-readme --coverageDir=./coverage",


### PR DESCRIPTION
Right now the package.json says this package is unlicensed, when it ships w/ MIT license included.