### PR TITLE
Bump version and include new nft metadata standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zoralabs/zdk",
   "description": "An SDK for using the Zora Media Protocol",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "files": [
@@ -25,7 +25,7 @@
   "dependencies": {
     "@zoralabs/auction-house": "^1.1.3",
     "@zoralabs/core": "^1.0.5",
-    "@zoralabs/media-metadata-schemas": "^0.1.2",
+    "@zoralabs/media-metadata-schemas": "^0.1.4",
     "axios": "^0.21.1",
     "eth-sig-util": "^3.0.0",
     "ethereumjs-util": "^7.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,10 +1554,10 @@
   dependencies:
     ethers "^5.0.19"
 
-"@zoralabs/media-metadata-schemas@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@zoralabs/media-metadata-schemas/-/media-metadata-schemas-0.1.2.tgz#b6f3532e7bca95197fa8a7ca136ad70dbdce1d2d"
-  integrity sha512-QcvPNb4RkdU9xKfOxnmKRKKVI4Z5oammiz2wYHmqzOvkIgHvm7tjV/MQcTelaRJfjksYx8k6bqsmbSbKIMUJTQ==
+"@zoralabs/media-metadata-schemas@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@zoralabs/media-metadata-schemas/-/media-metadata-schemas-0.1.4.tgz#22cce7fc83456abcf0b9ce98841dbdb44f8e14c6"
+  integrity sha512-F9Tjdgy2wocbKhia1zrPjMjn+Zlrd9WOu3GpWeqfcGa4tcM3ygjuMmG+IqG1SN5lMyoizFFR35MAlGHHVoKFFA==
   dependencies:
     "@types/jsonschema" "^1.1.1"
     jsonschema "^1.4.0"


### PR DESCRIPTION
Allows for usage of `zora-20210604` metadata standard with `generateMetadata` function by bumping dependent packages.