### PR TITLE
Add api key option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/zdk",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "ZDK alpha for fetching data from graphql api",
   "repository": "https://github.com/ourzora/zdk-alpha",
   "author": "Zora",

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ const DEFAULT_PROD_ENDPOINT = 'https://api.zora.co/graphql';
 
 type ZDKOptions = {
   endpoint?: string,
-  networks: OverrideNetworksOption,
+  networks?: OverrideNetworksOption,
   apiKey?: string,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
   SalesQueryFilter,
   OwnerCountQueryVariables,
   PaginationInput,
+  SdkFunctionWrapper,
 } from './queries/queries-sdk';
 
 // Export chain and network for API users
@@ -116,6 +117,12 @@ export interface ListOptions<SortInput> {
   includeFullDetails?: boolean;
 }
 
+export type SearchQueryArgs = {
+  query: string, 
+  filter?: SearchQueryVariables['filter'],
+  pagination?: SearchQueryVariables['pagination'],
+};
+
 export interface AggregateOptions {
   networks?: OverrideNetworksOption;
 }
@@ -128,22 +135,43 @@ type OptionalNetwork<K> = Omit<K, 'networks'> & {
 
 const DEFAULT_PROD_ENDPOINT = 'https://api.zora.co/graphql';
 
+type ZDKOptions = {
+  endpoint?: string,
+  networks: OverrideNetworksOption,
+  apiKey?: string,
+};
+
 export class ZDK {
   endpoint: string;
   defaultNetworks: OverrideNetworksOption;
-  defaultMaxPageSize: number = 200;
+  defaultMaxPageSize: number = 500;
+  apiKey?: string;
 
   public sdk: ReturnType<typeof getSdk>;
 
-  constructor(
-    endpoint: string = DEFAULT_PROD_ENDPOINT,
-    networks: OverrideNetworksOption = [
+  constructor({
+    endpoint = DEFAULT_PROD_ENDPOINT,
+    networks = [
       { network: Network.Ethereum, chain: Chain.Mainnet },
-    ]
-  ) {
+    ],
+    apiKey = undefined,
+  }: ZDKOptions) {
     this.endpoint = endpoint;
     this.defaultNetworks = networks;
-    this.sdk = getSdk(new GraphQLClient(this.endpoint));
+    this.sdk = getSdk(new GraphQLClient(this.endpoint), this.apiKeyWrapper);
+    this.apiKey = apiKey;
+  }
+
+  private apiKeyWrapper: SdkFunctionWrapper = async <T>(
+    action: (requestHeaders?:Record<string, string>
+  ) => Promise<T>): Promise<T> => {
+    const headers: Record<string, string> = {};
+    if (this.apiKey) {
+      headers['X-API-KEY'] = this.apiKey;
+    }
+
+    const result = await action(headers);
+    return result
   }
 
   private getNetworksOption = (networks?: OverrideNetworksOption) => {
@@ -388,10 +416,10 @@ export class ZDK {
       networks,
     });
 
-  public search = async ({ pagination, query, filter }: SearchQueryVariables) =>
+  public search = async ({ pagination, query, filter }: SearchQueryArgs) =>
     this.sdk.search({
-      pagination,
       filter,
-      query,
+      query: {text: query},
+      ...this.getPaginationOptions(pagination),
     });
 }

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -18,9 +18,9 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "eyJza2lwIjogMjAwfQ==",
+      "endCursor": "eyJza2lwIjogNTAwfQ==",
       "hasNextPage": false,
-      "limit": 200,
+      "limit": 500,
     },
   },
 }
@@ -44,9 +44,9 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "eyJza2lwIjogMjAwfQ==",
+      "endCursor": "eyJza2lwIjogNTAwfQ==",
       "hasNextPage": false,
-      "limit": 200,
+      "limit": 500,
     },
   },
 }
@@ -441,9 +441,9 @@ View this NFT at [zorb.dev/nft/48057](https://zorb.dev/nft/48057)",
       },
     ],
     "pageInfo": Object {
-      "endCursor": "eyJza2lwIjogMjAwfQ==",
+      "endCursor": "eyJza2lwIjogNTAwfQ==",
       "hasNextPage": false,
-      "limit": 200,
+      "limit": 500,
     },
   },
 }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -4,7 +4,7 @@ import { CollectionSortKey, SortDirection } from '../src/queries/queries-sdk';
 describe('zdk', () => {
   let zdk: ZDK;
   beforeEach(() => {
-    zdk = new ZDK(process.env.ZDK_ENDPOINT);
+    zdk = new ZDK({endpoint: process.env.ZDK_ENDPOINT});
   });
   it('should fetch localhost collections empty object', async () => {
     const apiResult = await zdk.tokens({

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -9,7 +9,7 @@ describe('unit zdk', () => {
   let querySpy: any;
   beforeEach(() => {
     querySpy = spyOn(registry, 'query');
-    zdk = new ZDK(ZORA_TESTING_PATH);
+    zdk = new ZDK({endpoint: ZORA_TESTING_PATH});
   });
 
   xit('gets mints', async () => {


### PR DESCRIPTION
Cleans up search query args and allows passing in an API key.

Minor version bump due to API change for ZDK constructor.